### PR TITLE
Updated webpack, tsconfig, jest and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ yarn-error.log*
 
 # Reports
 test-results/
+
+.idea
+/dist/
+
+**/*/.DS_Store

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,6 +17,6 @@ module.exports = {
   coverageDirectory: 'test-results',
   reporters: ['default'],
   moduleNameMapper: {
-    '~/(.*)$': '<rootDir>/src/$1'
+    '@/(.*)$': '<rootDir>/src/$1'
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,10 +10,13 @@ module.exports = {
   testEnvironment: 'node',
   verbose: true,
   collectCoverageFrom: [
-    "src/**",
-    "!src/@types/**",
-    "!**/*.spec.ts"
+    'src/**',
+    '!src/@types/**',
+    '!**/*.spec.ts'
   ],
   coverageDirectory: 'test-results',
-  reporters: ['default']
+  reporters: ['default'],
+  moduleNameMapper: {
+    '~/(.*)$': '<rootDir>/src/$1'
+  }
 }

--- a/src/handlers/hello.test.ts
+++ b/src/handlers/hello.test.ts
@@ -1,4 +1,4 @@
-import { hello } from '~/handlers/hello'
+import { hello } from '@/handlers/hello'
 
 describe('Complete Checkout Function', () => {
   it('should return dummy message', async () => {

--- a/src/handlers/hello.test.ts
+++ b/src/handlers/hello.test.ts
@@ -1,4 +1,4 @@
-import { hello } from './hello'
+import { hello } from '~/handlers/hello'
 
 describe('Complete Checkout Function', () => {
   it('should return dummy message', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
-      "~/*": [
+      "@/*": [
         "src/*"
       ]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
-    "lib": ["es2017"],
+    "lib": [
+      "es2017"
+    ],
     "esModuleInterop": true,
     "removeComments": true,
     "moduleResolution": "node",
@@ -8,9 +10,17 @@
     "noUnusedParameters": true,
     "sourceMap": true,
     "target": "es2017",
-    "outDir": "dist"
+    "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "~/*": [
+        "src/*"
+      ]
+    }
   },
-  "include": ["./**/*.ts"],
+  "include": [
+    "./**/*.ts"
+  ],
   "exclude": [
     "node_modules/**/*",
     ".serverless/**/*",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,9 @@ module.exports = {
       {
         test: /\.(tsx?)$/,
         loader: 'ts-loader',
+        include: [
+          path.resolve(__dirname, 'src'),
+        ],
         exclude: [
           [
             path.resolve(__dirname, 'node_modules'),
@@ -31,6 +34,12 @@ module.exports = {
           experimentalWatchApi: true,
         },
       },
-    ],
+    ]
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx'],
+    alias: {
+      '~': path.join(__dirname, 'src')
+    }
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = {
   resolve: {
     extensions: ['.ts', '.tsx'],
     alias: {
-      '~': path.join(__dirname, 'src')
+      '@': path.join(__dirname, 'src')
     }
   }
 }


### PR DESCRIPTION
- To help with using relative paths for reference a file in the `/src` folder.
- IDEs, like PHPStorm and VSCode, **path completion** and **jump to module** functionality should still work. (Webstorm I'd assume too)

**Screenshot example**;

<img width="1715" alt="Screenshot 2020-03-12 at 16 58 11" src="https://user-images.githubusercontent.com/45167545/76546476-75ea3c80-6483-11ea-8f07-79f8e9fb832a.png">
