### PR TITLE
re-order newrelic lambda layer

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -8,10 +8,10 @@ custom:
   ${file(config/custom.yml)}
 
 plugins:
-  - serverless-newrelic-lambda-layers
   - serverless-pseudo-parameters
   - serverless-webpack
-
+  - serverless-newrelic-lambda-layers
+  
 provider:
   name: aws
   runtime: nodejs12.x


### PR DESCRIPTION
The New Relic Lambda layer plugin needs to be at the bottom of the plugin list and most important  after webpack plugin. Otherwise it skipped by serverless framework on deployment